### PR TITLE
38 commentators will occasionally announce the wrong corner

### DIFF
--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -38,7 +38,8 @@ class Commentary:
 
     def generate(
             self, 
-            event, 
+            event,
+            lap_percent,
             role, 
             tone, 
             other_info="", 
@@ -52,6 +53,8 @@ class Commentary:
 
         Args:
             event (str): The event that occurred.
+            lap_percent (float): The percentage of the lap the event occurred
+                on.
             role (str): The role of the commentator.
             tone (str): The tone of the commentary.
             other_info (str): Additional information to be included in the
@@ -71,6 +74,7 @@ class Commentary:
         # Generate the commentary text
         text = self.text_generator.generate(
             event=event,
+            lap_percent=lap_percent,
             role=role,
             tone=tone,
             other_info=other_info
@@ -145,6 +149,8 @@ class TextGenerator:
         
         Args:
             event (str): The event that occurred.
+            lap_percent (float): The percentage of the lap the event occurred
+                on.
             role (str): The role of the commentator.
             tone (str): The tone of the commentary.
             other_info (str): Additional information to be included in the

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -265,14 +265,15 @@ class TextGenerator:
         messages.append(event_msg)
 
         # Add the lap percent message
-        lap_percent = round(lap_percent * 100, 2)
-        lap_msg = f"The event occurred at {lap_percent}% of the lap. "
-        lap_msg += "Infer the corner name or number based on that percentage."
-        lap_pct_msg = {
-            "role": "user",
-            "content": lap_msg
-        }
-        messages.append(lap_pct_msg)
+        if lap_percent != None:
+            lap_percent = round(lap_percent * 100, 2)
+            lap_msg = f"The event occurred at {lap_percent}% of the lap. "
+            lap_msg += "Infer the corner name or number based on that percentage."
+            lap_pct_msg = {
+                "role": "user",
+                "content": lap_msg
+            }
+            messages.append(lap_pct_msg)
 
         # Add the event message to previous messages
         self.previous_responses.append(event_msg)

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -271,7 +271,8 @@ class TextGenerator:
             lap_msg = f"The event occurred at {lap_percent}% of the lap. "
             lap_msg += "Infer the corner name or number based on that. "
             lap_msg += "Occasionally announce the corner name or number, but "
-            lap_msg += "do not do it every time."
+            lap_msg += "do not do it every time. Check the message history "
+            lap_msg += "to make sure you are not announcing corners too often."
             lap_pct_msg = {
                 "role": "user",
                 "content": lap_msg

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -183,6 +183,7 @@ class TextGenerator:
             new_msg += "You will respond with one to two short sentences. "
             new_msg += "Stick to providing insight or context that enhances "
             new_msg += "the viewer's understanding. "
+            new_msg += "Do not make up corner names or numbers. "
             new_msg += "Do not just say the word \"color\". "
 
         # Add common instructions
@@ -269,8 +270,8 @@ class TextGenerator:
             lap_percent = round(lap_percent * 100, 2)
             lap_msg = f"The event occurred at {lap_percent}% of the lap. "
             lap_msg += "Infer the corner name or number based on that. "
-            lap_msg += "Do not announce the corner name or number unless you "
-            lap_msg += "are certain of it. "
+            lap_msg += "Occasionally announce the corner name or number, but "
+            lap_msg += "do not do it every time."
             lap_pct_msg = {
                 "role": "user",
                 "content": lap_msg

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -265,7 +265,8 @@ class TextGenerator:
         messages.append(event_msg)
 
         # Add the lap percent message
-        lap_msg += f"The event occurred on {lap_percent}% of the lap. "
+        lap_percent = round(lap_percent * 100, 2)
+        lap_msg = f"The event occurred at {lap_percent}% of the lap. "
         lap_msg += "Infer the corner name or number based on that percentage."
         lap_pct_msg = {
             "role": "user",

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -135,7 +135,7 @@ class TextGenerator:
         # Create an empty list to hold previous responses
         self.previous_responses = []
     
-    def generate(self, event, role, tone, other_info=""):
+    def generate(self, event, lap_percent, role, tone, other_info=""):
         """Generate text commentary for the given event.
         
         Generates text commentary for the given event based on the provided
@@ -257,6 +257,15 @@ class TextGenerator:
             "content": event
         }
         messages.append(event_msg)
+
+        # Add the lap percent message
+        lap_msg += f"The event occurred on {lap_percent}% of the lap. "
+        lap_msg += "Infer the corner name or number based on that percentage."
+        lap_pct_msg = {
+            "role": "user",
+            "content": lap_msg
+        }
+        messages.append(lap_pct_msg)
 
         # Add the event message to previous messages
         self.previous_responses.append(event_msg)

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -268,7 +268,9 @@ class TextGenerator:
         if lap_percent != None:
             lap_percent = round(lap_percent * 100, 2)
             lap_msg = f"The event occurred at {lap_percent}% of the lap. "
-            lap_msg += "Infer the corner name or number based on that percentage."
+            lap_msg += "Infer the corner name or number based on that. "
+            lap_msg += "Do not announce the corner name or number unless you "
+            lap_msg += "are certain of it. "
             lap_pct_msg = {
                 "role": "user",
                 "content": lap_msg

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -93,6 +93,7 @@ class Director:
         if random.random() < chance:
             self.commentary.generate(
                 "Add color commentary to the previous commentary.",
+                None,
                 "color",
                 "neutral",
                 yelling=True,

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -114,6 +114,7 @@ class Director:
         # Generate the commentary
         self.commentary.generate(
             event["description"],
+            event["lap_percent"],
             "play-by-play",
             "neutral",
             common.instructions[event["type"]],

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -33,11 +33,21 @@ class Events:
             description (str): A description of the event
             focus (int): The number of the driver to focus on
         """
+        # Get the lap percent of the focused driver
+        if focus != None:
+            for driver in common.drivers:
+                if driver["number"] == focus:
+                    lap_percent = driver["lap_percent"]
+                    break
+        else:
+            lap_percent = None
+
         # Create a new event
         new_event = {
             "id": self.id_counter,
             "type": type,
             "description": description,
+            "lap_percent": lap_percent,
             "focus": focus,
             "timestamp": time.time()
         }


### PR DESCRIPTION
# Description

Corner name announcement is better, but not yet perfect. For now, the commentators are made aware of how far into the lap the focused driver is, and they infer the corner number from that. This currently has "good enough" accuracy, although better accuracy could be achieved with a custom list of corner numbers at their specific lap distance.

Fixes #38 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Tested on multiple replays at several different tracks with corner names:
- Laguna Seca
- Spa
- Zandvoort
- Monza

The corner naming was a lot more accurate, but not yet perfect.