### PR TITLE
69 drivers who stopped on track and then left continue to get reported as being stopped on track

### DIFF
--- a/src/core/events.py
+++ b/src/core/events.py
@@ -162,6 +162,12 @@ class Events:
                 if overtaken["laps_completed"] < 0:
                     continue
 
+                # If lap percent is exactly 0, driver is likely not on track
+                if driver["lap_percent"] == 0:
+                    continue
+                if overtaken["lap_percent"] == 0:
+                    continue
+
                 # If an legitimate overtake was found, add it to the events list
                 driver_name = common.remove_numbers(driver["name"])
                 overtaken_name = common.remove_numbers(overtaken["name"])
@@ -208,6 +214,10 @@ class Events:
 
                 # If laps completed is negative (DNF), don't report it
                 if driver["laps_completed"] < 0:
+                    continue
+
+                # If lap percent is exactly 0, driver is likely not on track
+                if driver["lap_percent"] == 0:
                     continue
 
                 # If a legitimate stopped car was found, add it to events list

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import time
+from pprint import pprint
 
 from core import common
 
@@ -228,6 +229,31 @@ class Events:
             if event["id"] == id:
                 self.events.remove(event)
 
+    def _remove_duplicates(self, events):
+        """Remove events with duplicate descriptions from the list, leaving only
+        the most recent event (which should be the first of its kind in the
+        list).
+
+        Args:
+            events (list): A list of events
+        
+        Returns:
+            list: A list of events with duplicates removed
+        """
+        # Create a new list to store the events
+        new_events = []
+
+        # Go through the events list
+        for event in events:
+            # If the event is not in the new list, add it
+            if event["description"] in [e["description"] for e in new_events]:
+                continue
+            else:
+                new_events.append(event)
+
+        # Return the new list
+        return new_events
+
     def _update_drivers(self):
         """Update the drivers list.
 
@@ -326,6 +352,11 @@ class Events:
         
         # Sort the events list by timestamp, with the most recent first
         self.events.sort(key=lambda x: x["timestamp"], reverse=True)
+
+        # Remove duplicate events
+        self.events = self._remove_duplicates(self.events)
+
+        pprint(self.events)
 
         # Event priority list
         priority = ["stopped", "overtake"]

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -232,7 +232,10 @@ class Events:
                 self._add("stopped", description, driver["number"])
 
                 # Update the driver's last stopped time
-                common.drivers[driver["idx"]]["last_stopped"] = time.time()
+                for i, d in enumerate(common.drivers):
+                    if d["name"] == driver["name"]:
+                        common.drivers[i]["last_stopped"] = time.time()
+                        break
 
                 # End this iteration of the loop
                 break

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 import time
-from pprint import pprint
 
 from core import common
 
@@ -377,8 +376,6 @@ class Events:
 
         # Remove duplicate events
         self.events = self._remove_duplicates(self.events)
-
-        pprint(self.events)
 
         # Event priority list
         priority = ["stopped", "overtake"]

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -105,6 +105,7 @@ class Events:
                     "laps_completed": 0,
                     "laps_started": 0,
                     "last_lap": None,
+                    "last_stopped": None,
                     "license": driver["LicString"],
                     "name": driver["UserName"],
                     "number": driver["CarNumberRaw"],
@@ -220,10 +221,18 @@ class Events:
                 if driver["lap_percent"] == 0:
                     continue
 
+                # If driver last stopped less than 10 seconds ago, don't report
+                if driver["last_stopped"]:
+                    if time.time() - driver["last_stopped"] < 10:
+                        continue
+
                 # If a legitimate stopped car was found, add it to events list
                 driver_name = common.remove_numbers(driver["name"])
                 description = f"{driver_name} is stopped on track"
                 self._add("stopped", description, driver["number"])
+
+                # Update the driver's last stopped time
+                common.drivers[driver["idx"]]["last_stopped"] = time.time()
 
                 # End this iteration of the loop
                 break


### PR DESCRIPTION
# Description

Detection of stopped drivers now goes through several additional checks to make sure the driver is on track and wasn't just reported as stopped within the last 10 seconds. There's also a new overall check in the get_next_event method which gets rid of repeat statements before picking an event to report.

Fixes #69 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Tested on a replay which caused significant issues with commentators hyper-focusing on stopped drivers. The behavior is significantly improved.