### PR TITLE
68 video export window needs improvement

### DIFF
--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -1,5 +1,6 @@
 import os
 
+from customtkinter import filedialog
 from moviepy.audio.AudioClip import CompositeAudioClip
 from moviepy.audio.fx.audio_normalize import audio_normalize
 from moviepy.audio.fx.volumex import volumex
@@ -142,6 +143,20 @@ class Editor:
         audio clips. This method is called by the main window when the user
         clicks the 'Stop Commentary' button.
         """
+        # Ask the user where to save the video
+        target = filedialog.asksaveasfilename(
+            filetypes=[(
+                "Video File",
+                f"*.{common.settings['general']['video_format']}"
+            )],
+            initialfile="output_video",
+            title="Save Video"
+        )
+        
+        # Return if the user canceled
+        if target == "":
+            return
+
         # Create export window
         export_window = export.Export(common.app)
 
@@ -171,7 +186,7 @@ class Editor:
 
         # Write the result to a file
         video.write_videofile(
-            f"output_video.{common.settings['general']['video_format']}",
+            f"{target}.{common.settings['general']['video_format']}",
             fps=int(common.settings["general"]["video_framerate"]),
             logger=export_window.progress_tracker
         )

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -158,6 +158,11 @@ class Editor:
         
         # Return if the user canceled
         if target == "":
+            # Clean up videos directory
+            self._delete_commentary_audio()
+            self._delete_latest_video()
+            self._delete_screenshot()
+
             return
 
         # Create export window

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -121,7 +121,10 @@ class Editor:
             VideoFileClip: The video clip
         """
         # Get the iRacing videos folder
-        path = os.path.join(common.settings["general"]["iracing_path"], "videos")
+        path = os.path.join(
+            common.settings["general"]["iracing_path"],
+            "videos"
+        )
 
         # Find the most recent .mp4 video in that folder
         files = []

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -167,16 +167,18 @@ class ProgressTracker(ProgressBarLogger):
         if text.startswith("Building video "):
             text = "Building video..."
 
-        # Custom message for building audio
+        # Custom message for building audio (also reset start time)
         if text.startswith("Writing audio "):
+            self.start_time = time.time()
             text = "Building audio track..."
 
         # Custom message for done
         if text.startswith("Done"):
             text = "Done!"
 
-        # Custom message for writing video
+        # Custom message for writing video (also reset start time)
         if text.startswith("Writing video "):
+            self.start_time = time.time()
             text = "Exporting video file..."
 
         # Custom final message and active the okay button

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -64,7 +64,7 @@ class Export(ctk.CTkToplevel):
         # Create a time remaining label
         self.lbl_time_remaining = ctk.CTkLabel(
             self,
-            text="Time remaining: Calculating...",
+            text="Estimated time remaining: Calculating...",
             font=ctk.CTkFont(size=12)
         )
         self.lbl_time_remaining.pack(pady=(0, 20))
@@ -202,7 +202,7 @@ class ProgressTracker(ProgressBarLogger):
 
         # Update time remaining label
         remaining = self._calculate_time_remaining(total)
-        self.remaining.configure(text=f"Time remaining: {remaining}")
+        self.remaining.configure(text=f"Estimated time remaining: {remaining}")
 
     def callback(self, **changes):
         """Callback method for the progress tracker

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -2,6 +2,80 @@ import customtkinter as ctk
 from proglog import ProgressBarLogger
 
 
+class CancelConfirm(ctk.CTkToplevel):
+    """Cancel confirmation window
+
+    The cancel confirmation window is a window that asks the user if they want
+    to cancel the video export. It is a child window of the export window.
+    """
+
+    def __init__(self, master):
+        """Constructor for the Cancel Confirmation window
+
+        Args:
+            master (CTk): The parent window
+        """
+        super().__init__(master)
+
+        # Set window properties
+        self.title("Cancel Export")
+        self.resizable(False, False)
+        self.attributes("-topmost", True)
+
+        # Reposition window
+        w = 400
+        h = 170
+        x = master.winfo_rootx() + (master.winfo_width() // 2) - (w // 2)
+        y = master.winfo_rooty() + (master.winfo_height() // 2) - (h // 2)
+        self.geometry(f"{w}x{h}+{x}+{y}")
+
+        # Create widgets
+        self._create_widgets()
+
+        # Bring window to front
+        self.lift()
+
+    def _confirm(self):
+        """Confirm cancel
+        
+        Confirms the cancel and destroys the export window.
+        """
+        # Destroy export window
+        self.master.destroy()
+
+        # Destroy cancel confirmation window
+        self.destroy()
+
+    def _create_widgets(self):
+        """Create widgets for the window
+        
+        Creates the widgets for the window and places them in the window. This
+        method is called by the constructor.
+        """
+        # Create message label
+        self.lbl_message = ctk.CTkLabel(
+            self,
+            text="Are you sure you want to cancel the export?",
+            font=ctk.CTkFont(size=14)
+        )
+        self.lbl_message.pack(pady=20)
+
+        # Create cancel button
+        self.btn_yes = ctk.CTkButton(
+            self,
+            text="Yes",
+            command=self._confirm
+        )
+        self.btn_yes.pack(pady=(0, 20))
+
+        # Create okay button
+        self.btn_no = ctk.CTkButton(
+            self,
+            text="No",
+            command=self.destroy
+        )
+        self.btn_no.pack(pady=(0, 20))
+
 class Export(ctk.CTkToplevel):
     """Export window
 
@@ -23,7 +97,6 @@ class Export(ctk.CTkToplevel):
         # Set window properties
         self.title("Export Video")
         self.resizable(False, False)
-        self.attributes("-topmost", True)
 
         # Reposition window
         w = 540
@@ -42,6 +115,19 @@ class Export(ctk.CTkToplevel):
             self.btn_cancel,
             self.btn_okay
         )
+
+        # Bring window to front
+        self.lift()
+
+    def _confirm_cancel(self):
+        """Confirm cancel
+        
+        Creates a cancel confirmation window and waits for the user to confirm
+        the cancel. If the user confirms the cancel, the export window is
+        destroyed by the cancel confirmation window.
+        """
+        # Create cancel confirmation window
+        CancelConfirm(self)
 
     def _create_widgets(self):
         """Create widgets for the window
@@ -70,7 +156,7 @@ class Export(ctk.CTkToplevel):
         self.btn_cancel = ctk.CTkButton(
             self,
             text="Cancel",
-            command=self.destroy
+            command=self._confirm_cancel
         )
         self.btn_cancel.pack(pady=(0, 20))
 

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -2,79 +2,6 @@ import customtkinter as ctk
 from proglog import ProgressBarLogger
 
 
-class CancelConfirm(ctk.CTkToplevel):
-    """Cancel confirmation window
-
-    The cancel confirmation window is a window that asks the user if they want
-    to cancel the video export. It is a child window of the export window.
-    """
-
-    def __init__(self, master):
-        """Constructor for the Cancel Confirmation window
-
-        Args:
-            master (CTk): The parent window
-        """
-        super().__init__(master)
-
-        # Set window properties
-        self.title("Cancel Export")
-        self.resizable(False, False)
-
-        # Reposition window
-        w = 400
-        h = 170
-        x = master.winfo_rootx() + (master.winfo_width() // 2) - (w // 2)
-        y = master.winfo_rooty() + (master.winfo_height() // 2) - (h // 2)
-        self.geometry(f"{w}x{h}+{x}+{y}")
-
-        # Create widgets
-        self._create_widgets()
-
-        # Bring window to front
-        self.lift()
-
-    def _confirm(self):
-        """Confirm cancel
-        
-        Confirms the cancel and destroys the export window.
-        """
-        # Destroy export window
-        self.master.destroy()
-
-        # Destroy cancel confirmation window
-        self.destroy()
-
-    def _create_widgets(self):
-        """Create widgets for the window
-        
-        Creates the widgets for the window and places them in the window. This
-        method is called by the constructor.
-        """
-        # Create message label
-        self.lbl_message = ctk.CTkLabel(
-            self,
-            text="Are you sure you want to cancel the export?",
-            font=ctk.CTkFont(size=14)
-        )
-        self.lbl_message.pack(pady=20)
-
-        # Create cancel button
-        self.btn_yes = ctk.CTkButton(
-            self,
-            text="Yes",
-            command=self._confirm
-        )
-        self.btn_yes.pack(pady=(0, 20))
-
-        # Create okay button
-        self.btn_no = ctk.CTkButton(
-            self,
-            text="No",
-            command=self.destroy
-        )
-        self.btn_no.pack(pady=(0, 20))
-
 class Export(ctk.CTkToplevel):
     """Export window
 
@@ -111,22 +38,11 @@ class Export(ctk.CTkToplevel):
         self.progress_tracker = ProgressTracker(
             self.lbl_message,
             self.prg_bar,
-            self.btn_cancel,
             self.btn_okay
         )
 
         # Bring window to front
         self.lift()
-
-    def _confirm_cancel(self):
-        """Confirm cancel
-        
-        Creates a cancel confirmation window and waits for the user to confirm
-        the cancel. If the user confirms the cancel, the export window is
-        destroyed by the cancel confirmation window.
-        """
-        # Create cancel confirmation window
-        CancelConfirm(self)
 
     def _create_widgets(self):
         """Create widgets for the window
@@ -151,20 +67,14 @@ class Export(ctk.CTkToplevel):
         self.prg_bar.pack(pady=(0, 20))
         self.prg_bar.set(0)
 
-        # Create cancel button
-        self.btn_cancel = ctk.CTkButton(
-            self,
-            text="Cancel",
-            command=self._confirm_cancel
-        )
-        self.btn_cancel.pack(pady=(0, 20))
-
-        # Create hidden okay button (don't pack it until the export is done)
+        # Create disabled okay button and pack it
         self.btn_okay = ctk.CTkButton(
             self,
             text="Okay",
+            state="disabled",
             command=self.destroy
         )
+        self.btn_okay.pack(pady=(0, 20))
 
 class ProgressTracker(ProgressBarLogger):
     """Progress tracker
@@ -173,7 +83,7 @@ class ProgressTracker(ProgressBarLogger):
     export. It is used by the export window to track the progress of the export.
     """
 
-    def __init__(self, message, progress, cancel, okay):
+    def __init__(self, message, progress, okay):
         """Constructor for the progress tracker
 
         Args:
@@ -185,7 +95,6 @@ class ProgressTracker(ProgressBarLogger):
         # Member variables
         self.message = message
         self.progress = progress
-        self.cancel = cancel
         self.okay = okay
 
     def _format_text(self, text):
@@ -223,11 +132,10 @@ class ProgressTracker(ProgressBarLogger):
         if text.startswith("Writing video "):
             text = "Exporting video file..."
 
-        # Custom final message and replace cancel button with okay button
+        # Custom final message and active the okay button
         if text.startswith("video ready "):
             text = "Video exported successfully!"
-            self.cancel.pack_forget()
-            self.okay.pack(pady=(0, 20))
+            self.okay.configure(state="normal")
 
         # Return the text
         return text

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -27,7 +27,7 @@ class Export(ctk.CTkToplevel):
 
         # Reposition window
         w = 540
-        h = 100
+        h = 150
         x = master.winfo_rootx() + (master.winfo_width() // 2) - (w // 2)
         y = master.winfo_rooty() + (master.winfo_height() // 2) - (h // 2)
         self.geometry(f"{w}x{h}+{x}+{y}")
@@ -36,7 +36,12 @@ class Export(ctk.CTkToplevel):
         self._create_widgets()
 
         # Create progress tracker object
-        self.progress_tracker = ProgressTracker(self.lbl_message, self.prg_bar)
+        self.progress_tracker = ProgressTracker(
+            self.lbl_message,
+            self.prg_bar,
+            self.btn_cancel,
+            self.btn_okay
+        )
 
     def _create_widgets(self):
         """Create widgets for the window
@@ -61,6 +66,21 @@ class Export(ctk.CTkToplevel):
         self.prg_bar.pack(pady=(0, 20))
         self.prg_bar.set(0)
 
+        # Create cancel button
+        self.btn_cancel = ctk.CTkButton(
+            self,
+            text="Cancel",
+            command=self.destroy
+        )
+        self.btn_cancel.pack(pady=(0, 20))
+
+        # Create hidden okay button (don't pack it until the export is done)
+        self.btn_okay = ctk.CTkButton(
+            self,
+            text="Okay",
+            command=self.destroy
+        )
+
 class ProgressTracker(ProgressBarLogger):
     """Progress tracker
 
@@ -68,7 +88,7 @@ class ProgressTracker(ProgressBarLogger):
     export. It is used by the export window to track the progress of the export.
     """
 
-    def __init__(self, message, progress):
+    def __init__(self, message, progress, cancel, okay):
         """Constructor for the progress tracker
 
         Args:
@@ -80,6 +100,8 @@ class ProgressTracker(ProgressBarLogger):
         # Member variables
         self.message = message
         self.progress = progress
+        self.cancel = cancel
+        self.okay = okay
 
     def _format_text(self, text):
         """Format text for the message label
@@ -116,9 +138,11 @@ class ProgressTracker(ProgressBarLogger):
         if text.startswith("Writing video "):
             text = "Writing video file..."
 
-        # Custom final message
+        # Custom final message and replace cancel button with okay button
         if text.startswith("video ready "):
             text = "Video exported successfully!"
+            self.cancel.pack_forget()
+            self.okay.pack(pady=(0, 20))
 
         # Return the text
         return text

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -109,7 +109,7 @@ class ProgressTracker(ProgressBarLogger):
         self.remaining = remaining
         self.okay = okay
 
-        # Note the start time
+        #
         self.start_time = time.time()
 
     def _calculate_time_remaining(self, progress):
@@ -124,15 +124,16 @@ class ProgressTracker(ProgressBarLogger):
         Returns:
             str: The time remaining
         """
-        # Calculate the time elapsed
-        elapsed = time.time() - self.start_time
-
         # If progress is 0, return "Calculating..."
         if progress == 0:
             return "Calculating..."
 
-        # Calculate the time remaining
-        remaining = (elapsed / progress) * (1 - progress)
+        # Calculate how long the current progress has taken
+        elapsed = time.time() - self.start_time
+
+        # Multiply the time it took to get to the current progress by the
+        # remaining progress to make an estimate of the time remaining
+        remaining = elapsed * (1 - progress)
 
         # Format the time remaining
         remaining = time.strftime("%H:%M:%S", time.gmtime(remaining))

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -222,7 +222,7 @@ class ProgressTracker(ProgressBarLogger):
 
         # Custom message for writing video
         if text.startswith("Writing video "):
-            text = "Writing video file..."
+            text = "Exporting video file..."
 
         # Custom final message and replace cancel button with okay button
         if text.startswith("video ready "):

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -20,7 +20,6 @@ class CancelConfirm(ctk.CTkToplevel):
         # Set window properties
         self.title("Cancel Export")
         self.resizable(False, False)
-        self.attributes("-topmost", True)
 
         # Reposition window
         w = 400

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -25,10 +25,11 @@ class Export(ctk.CTkToplevel):
         # Set window properties
         self.title("Export Video")
         self.resizable(False, False)
+        self.attributes("-topmost", True)
 
         # Reposition window
         w = 540
-        h = 150
+        h = 200
         x = master.winfo_rootx() + (master.winfo_width() // 2) - (w // 2)
         y = master.winfo_rooty() + (master.winfo_height() // 2) - (h // 2)
         self.geometry(f"{w}x{h}+{x}+{y}")

--- a/src/core/export.py
+++ b/src/core/export.py
@@ -110,7 +110,7 @@ class ProgressTracker(ProgressBarLogger):
         self.remaining = remaining
         self.okay = okay
 
-        #
+        # Keep track of the start time
         self.start_time = time.time()
 
     def _calculate_time_remaining(self, progress):
@@ -132,9 +132,11 @@ class ProgressTracker(ProgressBarLogger):
         # Calculate how long the current progress has taken
         elapsed = time.time() - self.start_time
 
-        # Multiply the time it took to get to the current progress by the
-        # remaining progress to make an estimate of the time remaining
-        remaining = elapsed * (1 - progress)
+        # Extrapolate how long the export will take
+        estimated_time = elapsed / progress
+
+        # Calculate how much time is remaining
+        remaining = estimated_time - elapsed
 
         # Format the time remaining
         remaining = time.strftime("%H:%M:%S", time.gmtime(remaining))


### PR DESCRIPTION
# Description

The export process now asks for a file save location before beginning to save the video. If none is given, no video is rendered. The export window now features a timer countdown (which is an estimate based on the time elapsed so far), as well as an "okay" button which is disabled until the video is finished rendering, at which point it becomes enabled to make it more clear to the user that the window can be closed.

It's worth noting that there was not an easy way to implement a cancel button, although that should be a future priority. Because of the way moviepy works (at least in the way it's implemented here), we are not given access to the rendered itself, and therefore cannot stop it once it starts without simply crashing the program intentionally. This seems like a solvable problem; however, it will be a much bigger task worthy of its own issue.

Fixes #68 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

This was tested by running commentary on a replay, and trying both letting it save and canceling the export before it starts.