### PR TITLE
39 file cleanup phase currently deletes all files in videos folder

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -924,6 +924,9 @@ class App(ctk.CTk):
             # Change button text
             self.btn_start_stop.configure(text="⏹ Stop Commentary")
 
+            # Run editor's cleanup in case of crash during previous run
+            self.editor.cleanup()
+
             # Run the director in a separate thread
             self.director.start()
 

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -444,6 +444,15 @@ class VoiceGenerator:
         # Save the audio to a file
         elevenlabs.save(audio, os.path.join(path, file_name))
 
+        # Add the new audio file to intellicaster.tmp
+        path = os.path.join(
+            common.settings["general"]["iracing_path"],
+            "videos",
+            "intellicaster.tmp"
+        )
+        with open(path, "a") as file:
+            file.write(f"{file_name}\n")
+
         # Get the length of the audio file
         mp3_file = MP3(os.path.join(path, file_name))
         length = mp3_file.info.length

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -232,13 +232,14 @@ class TextGenerator:
         # Start building the event info system message
         new_msg = ""
 
-        # Gather the information from iRacing
-        track = common.ir["WeekendInfo"]["TrackDisplayName"]
-        city = common.ir["WeekendInfo"]["TrackCity"]
-        country = common.ir["WeekendInfo"]["TrackCountry"]
-        air_temp = common.ir["WeekendInfo"]["TrackAirTemp"]
-        track_temp = common.ir["WeekendInfo"]["TrackSurfaceTemp"]
-        skies = common.ir["WeekendInfo"]["TrackSkies"]
+        # Gather the information from iRacing if it's running
+        if common.ir.is_initialized and common.ir.is_connected:
+            track = common.ir["WeekendInfo"]["TrackDisplayName"]
+            city = common.ir["WeekendInfo"]["TrackCity"]
+            country = common.ir["WeekendInfo"]["TrackCountry"]
+            air_temp = common.ir["WeekendInfo"]["TrackAirTemp"]
+            track_temp = common.ir["WeekendInfo"]["TrackSurfaceTemp"]
+            skies = common.ir["WeekendInfo"]["TrackSkies"]
 
         # Compile that information into a message
         new_msg += f"The race is at {track} in {city}, {country}. "

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -323,7 +323,7 @@ class TextGenerator:
 
                 # Get a list of all of the files
                 files = contents.split("\n")
-                
+
             if "screenshot.png" not in files:
                 with open(path, "a") as file:
                     file.write("screenshot.png\n")
@@ -463,12 +463,7 @@ class VoiceGenerator:
         elevenlabs.save(audio, os.path.join(path, file_name))
 
         # Add the new audio file to intellicaster.tmp
-        path = os.path.join(
-            common.settings["general"]["iracing_path"],
-            "videos",
-            "intellicaster.tmp"
-        )
-        with open(path, "a") as file:
+        with open(os.path.join(path, "intellicaster.tmp"), "a") as file:
             file.write(f"{file_name}\n")
 
         # Get the length of the audio file

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -310,6 +310,24 @@ class TextGenerator:
             screenshot_path = os.path.join(path, "screenshot.png")
             screenshot.save(screenshot_path)
 
+            # Add screenshot to intellicaster.tmp if it's not already there
+            path = os.path.join(
+                common.settings["general"]["iracing_path"],
+                "videos",
+                "intellicaster.tmp"
+            )
+
+            with open(path, "r") as file:
+                # Get the file contents
+                contents = file.read()
+
+                # Get a list of all of the files
+                files = contents.split("\n")
+                
+            if "screenshot.png" not in files:
+                with open(path, "a") as file:
+                    file.write("screenshot.png\n")
+
             # Process the image and save it
             with Image.open(screenshot_path) as image:
                 # Get the image's current dimensions

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -193,7 +193,7 @@ class Director:
         temporary file that keeps track of the files used by Intellicaster in
         the iRacing videos folder if it doesn't already exist.
         """
-        # Create a file in the videos folder called intellicaster.tmp if it doesn't exist
+        # Create a file in the videos folder called intellicaster.tmp if needed
         path = os.path.join(
             common.settings["general"]["iracing_path"],
             "videos",

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -189,8 +189,20 @@ class Director:
         """The main loop for the Director class.
 
         This method keeps running as long as the director is set to run. It
-        handles all of the logic for generating commentary.
+        handles all of the logic for generating commentary. It also creates the
+        temporary file that keeps track of the files used by Intellicaster in
+        the iRacing videos folder if it doesn't already exist.
         """
+        # Create a file in the videos folder called intellicaster.tmp if it doesn't exist
+        path = os.path.join(
+            common.settings["general"]["iracing_path"],
+            "videos",
+            "intellicaster.tmp"
+        )
+        if not os.path.exists(path):
+            with open(path, "w") as f:
+                f.write("intellicaster.tmp\n")
+
         # Create the camera manager
         self.camera = camera.Camera()
 

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -203,6 +203,22 @@ class Director:
             with open(path, "w") as f:
                 f.write("intellicaster.tmp\n")
 
+        # Get the video file with the most recent timestamp in the videos folder
+        path = os.path.join(
+            common.settings["general"]["iracing_path"],
+            "videos"
+        )
+        files = []
+        for file in os.listdir(path):
+            if file.endswith(common.settings["general"]["video_format"]):
+                files.append(os.path.join(path, file))
+        files.sort(key=os.path.getmtime)
+        latest_video = files[-1]
+
+        # Append the latest video to the intellicaster.tmp file
+        with open(os.path.join(path, "intellicaster.tmp"), "a") as f:
+            f.write(os.path.basename(latest_video) + "\n")
+        
         # Create the camera manager
         self.camera = camera.Camera()
 

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -51,63 +51,15 @@ class Editor:
             if file == "":
                 continue
 
+            # Get the path to the file
+            file_to_delete = os.path.join(
+                common.settings["general"]["iracing_path"],
+                "videos",
+                file
+            )
+
             # Delete the file
-            os.remove(file)
-
-    def _delete_commentary_audio(self):
-        """Delete the commentary audio clips from the iRacing videos folder
-
-        Deletes the commentary audio clips from the iRacing videos folder. This
-        is used to clean up the videos folder after the video has been exported.
-        """
-        # Get the iRacing videos folder
-        path = os.path.join(common.settings["general"]["iracing_path"], "videos")
-
-        # Get a list of all of the .mp3 files in that folder
-        files = []
-        for file in os.listdir(path):
-            if file.endswith(".mp3"):
-                files.append(os.path.join(path, file))
-
-        # Delete all of the .mp3 files
-        for file in files:
-            os.remove(file)
-
-    def _delete_latest_video(self):
-        """Delete the latest video from the iRacing videos folder
-        
-        Deletes the latest video from the iRacing videos folder. This is used to
-        clean up the videos folder after the video has been exported.
-        """
-        # Get the iRacing videos folder
-        path = os.path.join(common.settings["general"]["iracing_path"], "videos")
-
-        # Find the most recent .mp4 video in that folder
-        files = []
-        for file in os.listdir(path):
-            if file.endswith(".mp4"):
-                files.append(os.path.join(path, file))
-        latest_file = max(files, key=os.path.getctime)
-
-        # Delete the file
-        os.remove(latest_file)
-    
-    def _delete_screenshot(self):
-        """Delete the screenshot from the iRacing videos folder
-        
-        Deletes the screenshot from the iRacing videos folder. This is used to
-        clean up the videos folder after the video has been exported.
-        """
-        # Get the path to the screenshot
-        path = os.path.join(
-            common.settings["general"]["iracing_path"],
-            "videos",
-            "screenshot.png"
-        )
-
-        # Delete the file if it exists
-        if os.path.exists(path):
-            os.remove(path)
+            os.remove(file_to_delete)
 
     def _get_commentary_audio(self):
         """Get the commentary audio clips from the iRacing videos folder
@@ -194,9 +146,7 @@ class Editor:
         # Return if the user canceled
         if target == "":
             # Clean up videos directory
-            self._delete_commentary_audio()
-            self._delete_latest_video()
-            self._delete_screenshot()
+            self.cleanup()
 
             return
 
@@ -235,6 +185,4 @@ class Editor:
         )
 
         # Clean up videos directory
-        self._delete_commentary_audio()
-        self._delete_latest_video()
-        self._delete_screenshot()
+        self.cleanup()

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -19,6 +19,41 @@ class Editor:
     file.
     """
 
+    def cleanup(self):
+        """Clean up the videos folder
+
+        Cleans up the videos folder by deleting all of the files listed in the
+        intellicaster.tmp file. This is used to clean up the videos folder after
+        the video has been exported.
+        """
+        # Get the intellicaster.tmp file path
+        path = os.path.join(
+            common.settings["general"]["iracing_path"],
+            "videos",
+            "intellicaster.tmp"
+        )
+
+        # Return if the file doesn't exist
+        if not os.path.exists(path):
+            return
+        
+        # Read the file
+        with open(path, "r") as file:
+            # Get the file contents
+            contents = file.read()
+
+            # Get a list of all of the files
+            files = contents.split("\n")
+
+        # Delete all of the files
+        for file in files:
+            # Skip empty lines
+            if file == "":
+                continue
+
+            # Delete the file
+            os.remove(file)
+
     def _delete_commentary_audio(self):
         """Delete the commentary audio clips from the iRacing videos folder
 

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -58,8 +58,9 @@ class Editor:
                 file
             )
 
-            # Delete the file
-            os.remove(file_to_delete)
+            # Delete the file if it exist
+            if os.path.exists(file_to_delete):
+                os.remove(file_to_delete)
 
     def _get_commentary_audio(self):
         """Get the commentary audio clips from the iRacing videos folder

--- a/src/core/editor.py
+++ b/src/core/editor.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from customtkinter import filedialog
 from moviepy.audio.AudioClip import CompositeAudioClip
@@ -146,6 +147,9 @@ class Editor:
         
         # Return if the user canceled
         if target == "":
+            # Wait 3 seconds to ensure all of the files are written
+            time.sleep(3)
+
             # Clean up videos directory
             self.cleanup()
 
@@ -184,6 +188,9 @@ class Editor:
             fps=int(common.settings["general"]["video_framerate"]),
             logger=export_window.progress_tracker
         )
+
+        # Wait 3 seconds to ensure all of the files are written
+        time.sleep(3)
 
         # Clean up videos directory
         self.cleanup()


### PR DESCRIPTION
# Description

Rather than just deleting every video, audio, and image file in the iRacing videos folder (which is obviously terrible program behavior), a file called `intellicaster.tmp` is created in the videos folder to keep track of files created in the current session. A cleanup method is run in three places: when commentary is started, when commentary is ended and no video is exported, and when commentary is ended and a video is exported. This cleanup method deletes every file listed in `intellicaster.tmp`, leaving any other files the user has in that folder alone.

Fixes #39 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

A replay was run several times with files in the videos folder which shouldn't be deleted to ensure the correct files were deleted.