### PR TITLE
15 calculate gaps for each car

### DIFF
--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -254,6 +254,9 @@ class TextGenerator:
         }
         messages.append(event_msg)
 
+        # Add the event message to previous messages
+        self.previous_responses.append(event_msg)
+
         # Add the lap percent message
         if lap_percent != None:
             lap_percent = round(lap_percent * 100, 2)
@@ -269,8 +272,17 @@ class TextGenerator:
             }
             messages.append(lap_pct_msg)
 
-        # Add the event message to previous messages
-        self.previous_responses.append(event_msg)
+        # Add the gaps to leader message (from common.drivers)
+        gap_msg = "Here are the gaps to the leader: \n"
+        for driver in common.drivers:
+            gap_msg += f"{driver['name']}: {driver['gap_to_leader']}\n"
+        gap_msg += "Only use this information if it is relevant to the event. "
+        gap_msg += "If gaps have been mentioned recently, do not mention them."
+        gap_msg = {
+            "role": "user",
+            "content": gap_msg
+        }
+        messages.append(gap_msg)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -259,6 +259,7 @@ class TextGenerator:
             lap_percent = round(lap_percent * 100, 2)
             lap_msg = f"The event occurred at {lap_percent}% of the lap. "
             lap_msg += "Infer the corner name or number based on that. "
+            lap_msg += "Be sure to account for the length of straights. "
             lap_msg += "Occasionally announce the corner name or number, but "
             lap_msg += "do not do it every time. Check the message history "
             lap_msg += "to make sure you are not announcing corners too often."

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -194,7 +194,7 @@ class Director:
         the iRacing videos folder if it doesn't already exist.
         """
         # Wait one second to ensure video capture is started
-        time.sleep(1)
+        time.sleep(2)
         
         # Create a file in the videos folder called intellicaster.tmp if needed
         path = os.path.join(

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -399,7 +399,7 @@ class Events:
                 driver_total = driver_current + driver_laps
 
                 # Calculate the gap to leader
-                gap_to_leader = driver_total - leader_total
+                gap_to_leader = leader_total - driver_total
 
                 # Update the driver's gap to leader
                 common.drivers[i]["gap_to_leader"] = gap_to_leader

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -93,6 +93,7 @@ class Events:
             driver_dict.append(
                 {
                     "car_name": driver["CarScreenNameShort"],
+                    "current_lap_time": 0,
                     "fastest_lap": None,
                     "gap_to_leader": None,
                     "grid_position": quali_pos,
@@ -103,6 +104,7 @@ class Events:
                     "lap_percent": 0,
                     "laps_completed": 0,
                     "laps_started": 0,
+                    "lap_times": [],
                     "last_lap": None,
                     "last_stopped": None,
                     "license": driver["LicString"],

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -303,6 +303,9 @@ class Events:
                 # Find the driver in the drivers list at this index
                 for j, driver in enumerate(common.drivers):
                     if driver["idx"] == i:
+                        # Get old last lap for later comparison
+                        old_last_lap = driver["last_lap_time"]
+
                         # Get the driver's last lap time if it exists
                         last_lap_time = common.ir["CarIdxLastLapTime"][i]
                         if last_lap_time > 0: 
@@ -317,6 +320,10 @@ class Events:
                         elif last_lap_time < driver["fastest_lap"]:
                             if last_lap_time > 0:
                                 common.drivers[j]["fastest_lap"] = last_lap_time
+                        
+                        # If new last lap different than old, append to lap list
+                        if last_lap_time != old_last_lap and last_lap_time > 0:
+                            common.drivers[j]["lap_times"].append(last_lap_time)
 
                         # Update percentage of lap completed
                         lap_percent = common.ir["CarIdxLapDistPct"][i]

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -303,17 +303,20 @@ class Events:
                 # Find the driver in the drivers list at this index
                 for j, driver in enumerate(common.drivers):
                     if driver["idx"] == i:
-                        # Get the driver's last lap time
+                        # Get the driver's last lap time if it exists
                         last_lap_time = common.ir["CarIdxLastLapTime"][i]
-                        common.drivers[j]["last_lap_time"] = last_lap_time
+                        if last_lap_time > 0: 
+                            common.drivers[j]["last_lap_time"] = last_lap_time
 
                         # If there's no fastest lap, set it to the last lap
                         if driver["fastest_lap"] == None:
-                            common.drivers[j]["fastest_lap"] = last_lap_time
+                            if last_lap_time > 0:
+                                common.drivers[j]["fastest_lap"] = last_lap_time
                         
                         # If the last lap is faster than the fastest lap, update
                         elif last_lap_time < driver["fastest_lap"]:
-                            common.drivers[j]["fastest_lap"] = last_lap_time
+                            if last_lap_time > 0:
+                                common.drivers[j]["fastest_lap"] = last_lap_time
 
                         # Update percentage of lap completed
                         lap_percent = common.ir["CarIdxLapDistPct"][i]

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -325,6 +325,10 @@ class Events:
                         if last_lap_time != old_last_lap and last_lap_time > 0:
                             common.drivers[j]["lap_times"].append(last_lap_time)
 
+                        # Update the current lap time
+                        current_lap_time = common.ir["CarIdxEstTime"][i]
+                        common.drivers[j]["current_lap_time"] = current_lap_time
+
                         # Update percentage of lap completed
                         lap_percent = common.ir["CarIdxLapDistPct"][i]
                         common.drivers[j]["lap_percent"] = lap_percent

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -105,7 +105,7 @@ class Events:
                     "laps_completed": 0,
                     "laps_started": 0,
                     "lap_times": [],
-                    "last_lap": None,
+                    "last_lap_time": None,
                     "last_stopped": None,
                     "license": driver["LicString"],
                     "name": driver["UserName"],
@@ -304,16 +304,16 @@ class Events:
                 for j, driver in enumerate(common.drivers):
                     if driver["idx"] == i:
                         # Get the driver's last lap time
-                        last_lap = common.ir["CarIdxLastLapTime"][i]
-                        common.drivers[j]["last_lap"] = last_lap
+                        last_lap_time = common.ir["CarIdxLastLapTime"][i]
+                        common.drivers[j]["last_lap_time"] = last_lap_time
 
                         # If there's no fastest lap, set it to the last lap
                         if driver["fastest_lap"] == None:
-                            common.drivers[j]["fastest_lap"] = last_lap
+                            common.drivers[j]["fastest_lap"] = last_lap_time
                         
                         # If the last lap is faster than the fastest lap, update
-                        elif last_lap < driver["fastest_lap"]:
-                            common.drivers[j]["fastest_lap"] = last_lap
+                        elif last_lap_time < driver["fastest_lap"]:
+                            common.drivers[j]["fastest_lap"] = last_lap_time
 
                         # Update percentage of lap completed
                         lap_percent = common.ir["CarIdxLapDistPct"][i]

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -377,6 +377,33 @@ class Events:
         else:
             common.drivers.sort(key=lambda x: x["grid_position"])
 
+        # After sorting by position, update the gaps
+        for i, driver in enumerate(common.drivers):
+            # If the driver is the leader, gap to leader is 0
+            if i == 0:
+                common.drivers[i]["gap_to_leader"] = 0.
+
+            # Otherwise, calculate the gap to leader
+            else:
+                # Get the leader car
+                leader = common.drivers[0]
+                
+                # Get the leader's current lap time plus all previous laps
+                leader_current = leader["current_lap_time"]
+                leader_laps = sum(leader["lap_times"])
+                leader_total = leader_current + leader_laps
+
+                # Get this driver's current lap time plus all previous laps
+                driver_current = driver["current_lap_time"]
+                driver_laps = sum(driver["lap_times"])
+                driver_total = driver_current + driver_laps
+
+                # Calculate the gap to leader
+                gap_to_leader = driver_total - leader_total
+
+                # Update the driver's gap to leader
+                common.drivers[i]["gap_to_leader"] = gap_to_leader
+
     def get_next_event(self):
         """Pick the next event to report.
         


### PR DESCRIPTION
# Description

The gap to leader is now calculated for all cars, along with their current lap time relative to their position on track and their lap times across the session. The gaps are also being fed to the commentary instructions to improve commentary by making it more specific.

Fixes #15 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Commentary was run while printing out the newly generated data and watching commentary to see if it said anything odd.