### PR TITLE
74 allow commentary to be aware of multiple events

### DIFF
--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -6,6 +6,7 @@ from mutagen.mp3 import MP3
 import openai
 
 from core import common
+from pprint import pprint
 
 
 class Commentary:
@@ -297,6 +298,8 @@ class TextGenerator:
             "content": gap_msg
         }
         messages.append(gap_msg)
+
+        # pprint(messages)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -140,7 +140,7 @@ class TextGenerator:
 
         # Add the lap percentage
         adjusted_percent = event["lap_percent"] * 100.
-        event_str += f"{event['lap_percent']}% of the way through the lap - "
+        event_str += f"{adjusted_percent}% of the way through the lap - "
 
         # Get the amount of time ago it occurred
         time_ago = time.time() - event["timestamp"]

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -140,10 +140,12 @@ class TextGenerator:
 
         # Add the lap percentage
         adjusted_percent = event["lap_percent"] * 100.
+        adjusted_percent = round(adjusted_percent, 3)
         event_str += f"{adjusted_percent}% of the way through the lap - "
 
         # Get the amount of time ago it occurred
         time_ago = time.time() - event["timestamp"]
+        time_ago = round(time_ago, 3)
 
         # Add the time
         event_str += f"{time_ago} seconds ago"
@@ -282,7 +284,8 @@ class TextGenerator:
         # Add the gaps to leader message (from common.drivers)
         gap_msg = "\n\nHere are the gaps to the leader:\n"
         for driver in common.drivers:
-            gap_msg += f"- {driver['name']}: {driver['gap_to_leader']}"
+            rounded_gap = round(driver["gap_to_leader"], 3)
+            gap_msg += f"- {driver['name']}: {rounded_gap}"
             gap_msg += "\n"
         gap_msg += "Only use this information if it is relevant to the event. "
         gap_msg += "If gaps have been mentioned recently, do not mention them."

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -284,7 +284,7 @@ class TextGenerator:
         messages.append(event_msg)
 
         # Add the gaps to leader message (from common.drivers)
-        gap_msg = "\n\nHere are the gaps to the leader:\n"
+        gap_msg = "Here are the gaps to the leader:\n"
         for driver in common.drivers:
             rounded_gap = round(driver["gap_to_leader"], 3)
             gap_msg += f"- {driver['name']}: +{rounded_gap}"

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -275,7 +275,7 @@ class TextGenerator:
         event_msg += "If two events are related, mention them together. "
         event_msg += "DO NOT mention the exact time of the event. "
         event_msg += "Use the lap distance to estimate the corner name/number. "
-        event_msg += "Do not repeat events that have already been mentioned. "
+        event_msg += "NEVER repeat events that have already been mentioned. "
         event_msg = {
             "role": "user",
             "content": event_msg

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -219,13 +219,9 @@ class TextGenerator:
         previous responses.
         
         Args:
-            event (str): The event that occurred.
-            lap_percent (float): The percentage of the lap the event occurred
-                on.
+            events (list): A list of events that have occurred.
             role (str): The role of the commentator.
-            tone (str): The tone of the commentary.
-            other_info (str): Additional information to be included in the
-                system message.
+            camera (int): The car number to focus on.
         
         Returns:
             str: The generated commentary.

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -273,6 +273,8 @@ class TextGenerator:
             event_msg += "\n"
         event_msg += "Report on the most exciting events. "
         event_msg += "If two events are related, mention them together. "
+        event_msg += "DO NOT mention the exact time of the event. "
+        event_msg += "Use the lap distance to estimate the corner name/number. "
         event_msg += "Do not repeat events that have already been mentioned. "
         event_msg = {
             "role": "user",

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -139,11 +139,11 @@ class TextGenerator:
         event_str += f"{event['description']} - "
 
         # Add the lap percentage
+        adjusted_percent = event["lap_percent"] * 100.
         event_str += f"{event['lap_percent']}% of the way through the lap - "
 
-        # Get the amount of time ago it occurred and round it to hundredths
+        # Get the amount of time ago it occurred
         time_ago = time.time() - event["timestamp"]
-        time_ago = round(time_ago, 2)
 
         # Add the time
         event_str += f"{time_ago} seconds ago"

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -285,7 +285,7 @@ class TextGenerator:
         gap_msg = "\n\nHere are the gaps to the leader:\n"
         for driver in common.drivers:
             rounded_gap = round(driver["gap_to_leader"], 3)
-            gap_msg += f"- {driver['name']}: {rounded_gap}"
+            gap_msg += f"- {driver['name']}: +{rounded_gap}"
             gap_msg += "\n"
         gap_msg += "Only use this information if it is relevant to the event. "
         gap_msg += "If gaps have been mentioned recently, do not mention them."

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -286,8 +286,9 @@ class TextGenerator:
         # Add the gaps to leader message (from common.drivers)
         gap_msg = "Here are the gaps to the leader:\n"
         for driver in common.drivers:
+            driver_name = common.remove_numbers(driver["name"])
             rounded_gap = round(driver["gap_to_leader"], 3)
-            gap_msg += f"- {driver['name']}: +{rounded_gap}"
+            gap_msg += f"- {driver_name}: +{rounded_gap}"
             gap_msg += "\n"
         gap_msg += "Only use this information if it is relevant to the event. "
         gap_msg += "If gaps have been mentioned recently, do not mention them."

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -36,7 +36,8 @@ class Commentary:
             self, 
             events,
             role,
-            rec_start_time=0
+            rec_start_time=0,
+            camera=None
         ):
         """Generate commentary for the given event.
 

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -262,7 +262,7 @@ class TextGenerator:
         }
         messages.append(sys_event)
 
-        # Add all previous messages to the list
+        # Add all previous responses to the list
         for msg in self.previous_responses:
             messages.append(msg)
 
@@ -283,9 +283,6 @@ class TextGenerator:
         }
         messages.append(event_msg)
 
-        # Add the event message to previous messages
-        self.previous_responses.append(event_msg)
-
         # Add the gaps to leader message (from common.drivers)
         gap_msg = "\n\nHere are the gaps to the leader:\n"
         for driver in common.drivers:
@@ -299,7 +296,10 @@ class TextGenerator:
         }
         messages.append(gap_msg)
 
-        # pprint(messages)
+        print()
+        print("--------------------")
+        print()
+        pprint(messages)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -264,6 +264,26 @@ class TextGenerator:
         }
         messages.append(sys_event)
 
+        # Add the gaps to leader message (from common.drivers)
+        gap_msg = "Here are the gaps to the leader:\n"
+        for driver in common.drivers:
+            driver_name = common.remove_numbers(driver["name"])
+            rounded_gap = round(driver["gap_to_leader"], 3)
+            gap_msg += f"- {driver_name}: +{rounded_gap}"
+            gap_msg += "\n"
+        gap_msg += "Only use this information if it is relevant to the event. "
+        gap_msg += "If gaps have been mentioned recently, do not mention them."
+        gap_msg = {
+            "role": "system",
+            "name": "gaps_to_leader",
+            "content": gap_msg
+        }
+        messages.append(gap_msg)
+
+        # Add all previous responses to the list
+        for msg in self.previous_responses:
+            messages.append(msg)
+
         # Add the event messages if this is the play-by-play role
         if role == "play-by-play":
             event_msg = "The following events have recently occurred:\n"
@@ -284,29 +304,10 @@ class TextGenerator:
             }
             messages.append(event_msg)
 
-        # Add the gaps to leader message (from common.drivers)
-        gap_msg = "Here are the gaps to the leader:\n"
-        for driver in common.drivers:
-            driver_name = common.remove_numbers(driver["name"])
-            rounded_gap = round(driver["gap_to_leader"], 3)
-            gap_msg += f"- {driver_name}: +{rounded_gap}"
-            gap_msg += "\n"
-        gap_msg += "Only use this information if it is relevant to the event. "
-        gap_msg += "If gaps have been mentioned recently, do not mention them."
-        gap_msg = {
-            "role": "user",
-            "content": gap_msg
-        }
-        messages.append(gap_msg)
-
         print()
         print("--------------------")
         print()
         pprint(messages)
-
-        # Add all previous responses to the list
-        for msg in self.previous_responses:
-            messages.append(msg)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -68,6 +68,7 @@ class Commentary:
         text = self.text_generator.generate(
             events=events,
             role=role,
+            camera=camera
         )
 
         # Add the message to the message box
@@ -152,7 +153,7 @@ class TextGenerator:
 
         return event_str
 
-    def generate(self, events, role):
+    def generate(self, events, role, camera=None):
         """Generate text commentary for the given event.
         
         Generates text commentary for the given event based on the provided

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -264,24 +264,25 @@ class TextGenerator:
         }
         messages.append(sys_event)
 
-        # Add the event messages
-        event_msg = "The following events have recently occurred:\n"
-        for event in events:
-            parsed_event = self._parse_event(event)
-            event_msg += f"- {parsed_event}"
-            event_msg += "\n"
-        event_msg += "Report on the most exciting events. "
-        event_msg += "If two events are related, mention them together. "
-        event_msg += "Determine if events are related by type, lap percentage, "
-        event_msg += "and/or time. "
-        event_msg += "DO NOT mention the exact time of the event. "
-        event_msg += "Use the lap distance to estimate the corner name/number. "
-        event_msg += "NEVER repeat events that have already been mentioned. "
-        event_msg = {
-            "role": "user",
-            "content": event_msg
-        }
-        messages.append(event_msg)
+        # Add the event messages if this is the play-by-play role
+        if role == "play-by-play":
+            event_msg = "The following events have recently occurred:\n"
+            for event in events:
+                parsed_event = self._parse_event(event)
+                event_msg += f"- {parsed_event}"
+                event_msg += "\n"
+            event_msg += "Report on the most exciting events. "
+            event_msg += "If two events are related, mention them together. "
+            event_msg += "Determine if events are related by type, "
+            event_msg += "lap percentage, and/or time. "
+            event_msg += "DO NOT mention the exact time of the event. "
+            event_msg += "Use lap distance to estimate the corner name/number. "
+            event_msg += "NEVER repeat events that have already been mentioned."
+            event_msg = {
+                "role": "user",
+                "content": event_msg
+            }
+            messages.append(event_msg)
 
         # Add the gaps to leader message (from common.drivers)
         gap_msg = "Here are the gaps to the leader:\n"

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -262,10 +262,6 @@ class TextGenerator:
         }
         messages.append(sys_event)
 
-        # Add all previous responses to the list
-        for msg in self.previous_responses:
-            messages.append(msg)
-
         # Add the event messages
         event_msg = "The following events have recently occurred:\n"
         for event in events:
@@ -300,6 +296,10 @@ class TextGenerator:
         print("--------------------")
         print()
         pprint(messages)
+
+        # Add all previous responses to the list
+        for msg in self.previous_responses:
+            messages.append(msg)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -119,6 +119,36 @@ class TextGenerator:
         # Create an empty list to hold previous responses
         self.previous_responses = []
     
+    def _parse_event(self, event):
+        """Parse the event dictionary to create a string.
+        
+        Args:
+            event (dict): The event dictionary to parse.
+            
+        Returns:
+            str: The parsed event string.
+        """
+        # Create the string to return
+        event_str = ""
+        
+        # Add the event type
+        event_str += f"{event['type']} - "
+
+        # Add the description
+        event_str += f"{event['description']} - "
+
+        # Add the lap percentage
+        event_str += f"{event['lap_percent']}% of the way through the lap - "
+
+        # Get the amount of time ago it occurred and round it to hundredths
+        time_ago = time.time() - event["timestamp"]
+        time_ago = round(time_ago, 2)
+
+        # Add the time
+        event_str += f"{time_ago} seconds ago"
+
+        return event_str
+
     def generate(self, events, role):
         """Generate text commentary for the given event.
         
@@ -238,7 +268,8 @@ class TextGenerator:
         # Add the event messages
         event_msg = "The following events have recently occurred:\n"
         for event in events:
-            event_msg += f"- {event}"
+            parsed_event = self._parse_event(event)
+            event_msg += f"- {parsed_event}"
             event_msg += "\n"
         event_msg += "Report on the most exciting events. "
         event_msg += "If two events are related, mention them together. "

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -272,6 +272,8 @@ class TextGenerator:
             event_msg += "\n"
         event_msg += "Report on the most exciting events. "
         event_msg += "If two events are related, mention them together. "
+        event_msg += "Determine if events are related by type, lap percentage, "
+        event_msg += "and/or time. "
         event_msg += "DO NOT mention the exact time of the event. "
         event_msg += "Use the lap distance to estimate the corner name/number. "
         event_msg += "NEVER repeat events that have already been mentioned. "

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -6,7 +6,6 @@ from mutagen.mp3 import MP3
 import openai
 
 from core import common
-from pprint import pprint
 
 
 class Commentary:
@@ -303,11 +302,6 @@ class TextGenerator:
                 "content": event_msg
             }
             messages.append(event_msg)
-
-        print()
-        print("--------------------")
-        print()
-        pprint(messages)
 
         # Call the API
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -372,9 +372,15 @@ class TextGenerator:
                 current_time = common.race_time
                 total_time = common.ir["SessionTimeTotal"]
 
-                # Convert the times to minutes and seconds
-                current_time = time.strftime("%M:%S", time.gmtime(current_time))
-                total_time = time.strftime("%M:%S", time.gmtime(total_time))
+                # Convert the times to hours, minutes, and seconds
+                current_time = time.strftime(
+                    "%H:%M:%S",
+                    time.gmtime(current_time)
+                )
+                total_time = time.strftime(
+                    "%H:%M:%S",
+                    time.gmtime(total_time)
+                )
 
                 # Add the time information to the message
                 event_msg += f"{current_time} of {total_time} has elapsed "

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -292,11 +292,11 @@ class TextGenerator:
             }
             messages.append(sys_context)
 
-        # Start building the event info system message
-        new_msg = ""
-
-        # Gather the information from iRacing if it's running
+        # Start building the event info system message if iRacing is connected
         if common.ir.is_initialized and common.ir.is_connected:
+            new_msg = ""
+
+            # Gather the information
             track = common.ir["WeekendInfo"]["TrackDisplayName"]
             city = common.ir["WeekendInfo"]["TrackCity"]
             country = common.ir["WeekendInfo"]["TrackCountry"]
@@ -304,19 +304,19 @@ class TextGenerator:
             track_temp = common.ir["WeekendInfo"]["TrackSurfaceTemp"]
             skies = common.ir["WeekendInfo"]["TrackSkies"]
 
-        # Compile that information into a message
-        new_msg += f"The race is at {track} in {city}, {country}. "
-        new_msg += f"The air temperature is {air_temp}., and "
-        new_msg += f"the track temperature is {track_temp}. "
-        new_msg += f"The skies are {skies.lower()}. "
+            # Compile that information into a message
+            new_msg += f"The race is at {track} in {city}, {country}. "
+            new_msg += f"The air temperature is {air_temp}., and "
+            new_msg += f"the track temperature is {track_temp}. "
+            new_msg += f"The skies are {skies.lower()}. "
 
-        # Add the event info system message
-        sys_event = {
-            "role": "system",
-            "name": "event_info",
-            "content": new_msg
-        }
-        messages.append(sys_event)
+            # Add the event info system message
+            sys_event = {
+                "role": "system",
+                "name": "event_info",
+                "content": new_msg
+            }
+            messages.append(sys_event)
 
         # Add the gaps to leader message (from common.drivers)
         gap_msg = "Here are the gaps to the leader:\n"

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -94,7 +94,8 @@ class Director:
             self.commentary.generate(
                 "Add color commentary to the previous commentary.",
                 "color",
-                rec_start_time=common.recording_start_time
+                rec_start_time=common.recording_start_time,
+                camera=self.camera
             )
 
     def _generate_event_commentary(self, events):
@@ -113,7 +114,8 @@ class Director:
         self.commentary.generate(
             events,
             "play-by-play",
-            rec_start_time=common.recording_start_time
+            rec_start_time=common.recording_start_time,
+            camera=self.camera
         )
 
     def _update_iracing_settings(self):

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -217,7 +217,7 @@ class Director:
         # Keep running until told to stop
         while common.running:
             # Detect if the race has started
-            if common.ir["RaceLaps"] > 0 and not common.race_started:
+            if common.ir["SessionState"] == 4 and not common.race_started:
                 common.race_started = True
                 common.start_time = common.ir["SessionTime"]
 
@@ -262,6 +262,10 @@ class Director:
 
                 # Switch to the first car that's not in the pits
                 self.camera.change_camera(driver, "TV1")
+
+                # Wait a tenth of a second, then continue to update quickly
+                time.sleep(0.1)
+                continue
 
             # Check if all cars have crossed the start line if needed
             if not common.all_cars_started:

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -101,15 +101,9 @@ class Director:
     def _generate_event_commentary(self, events):
         """Generate commentary for an event.
 
-        This method generates commentary for a specified event. It also changes
-        the camera to focus on the event.
-
         Args:
             event (dict): A dictionary containing information about the event.
         """
-        # Move the camera to focus on the event
-        # self.camera.change_camera(event["focus"], "TV1")
-
         # Generate the commentary
         self.commentary.generate(
             events,

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -93,14 +93,11 @@ class Director:
         if random.random() < chance:
             self.commentary.generate(
                 "Add color commentary to the previous commentary.",
-                None,
                 "color",
-                "neutral",
-                yelling=True,
                 rec_start_time=common.recording_start_time
             )
 
-    def _generate_event_commentary(self, event):
+    def _generate_event_commentary(self, events):
         """Generate commentary for an event.
 
         This method generates commentary for a specified event. It also changes
@@ -110,16 +107,12 @@ class Director:
             event (dict): A dictionary containing information about the event.
         """
         # Move the camera to focus on the event
-        self.camera.change_camera(event["focus"], "TV1")
+        # self.camera.change_camera(event["focus"], "TV1")
 
         # Generate the commentary
         self.commentary.generate(
-            event["description"],
-            event["lap_percent"],
+            events,
             "play-by-play",
-            "neutral",
-            common.instructions[event["type"]],
-            yelling=True,
             rec_start_time=common.recording_start_time
         )
 
@@ -280,12 +273,12 @@ class Director:
 
             # If the race has started, generate commentary
             if common.race_started and common.all_cars_started:
-                # Get the next event to generate commentary for
-                event = self.events.get_next_event()
+                # Get the list of recent events
+                events = self.events.get_events()
 
                 # If an event was found, report it
-                if event:
-                    self._generate_event_commentary(event)
+                if len(events) > 0:
+                    self._generate_event_commentary(events)
 
                 # Occasionally generate color commentary
                 self._generate_color_commentary()

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -281,7 +281,7 @@ class Director:
                     self._generate_event_commentary(events)
 
                 # Occasionally generate color commentary
-                # self._generate_color_commentary()
+                self._generate_color_commentary()
             
             # Wait the amount of time specified in the settings
             time.sleep(float(common.settings["system"]["director_update_freq"]))

--- a/src/core/director.py
+++ b/src/core/director.py
@@ -281,7 +281,7 @@ class Director:
                     self._generate_event_commentary(events)
 
                 # Occasionally generate color commentary
-                self._generate_color_commentary()
+                # self._generate_color_commentary()
             
             # Wait the amount of time specified in the settings
             time.sleep(float(common.settings["system"]["director_update_freq"]))

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -421,39 +421,6 @@ class Events:
 
         # Return the events list
         return self.events
-
-    def get_next_event(self):
-        """Pick the next event to report.
-        
-        Returns:
-            dict: The next event to report
-        """
-        # If there are no events, return None
-        if not self.events:
-            return None
-        
-        # Sort the events list by timestamp, with the most recent first
-        self.events.sort(key=lambda x: x["timestamp"], reverse=True)
-
-        # Remove duplicate events
-        self.events = self._remove_duplicates(self.events)
-
-        # Event priority list
-        priority = ["stopped", "overtake"]
-
-        # Go through the priority list
-        for p in priority:
-            # Go through the events list
-            for event in self.events:
-                # If the event type matches the priority, return it
-                if event["type"] == p:
-                    self._remove(event["id"])
-                    return event
-
-        # As a fallback, return the first event in the list and remove it
-        event = self.events[0]
-        self._remove(event["id"])
-        return event
     
     def run(self):
         """Run the events thread.

--- a/src/core/events.py
+++ b/src/core/events.py
@@ -404,6 +404,24 @@ class Events:
                 # Update the driver's gap to leader
                 common.drivers[i]["gap_to_leader"] = gap_to_leader
 
+    def get_events(self):
+        """Get the events list.
+        
+        Sort the events list by timestamp and remove duplicates before returning
+        it.
+        
+        Returns:
+            list: The events list
+        """
+        # Sort the events list by timestamp
+        self.events.sort(key=lambda x: x["timestamp"], reverse=True)
+
+        # Remove duplicate events
+        self.events = self._remove_duplicates(self.events)
+
+        # Return the events list
+        return self.events
+
     def get_next_event(self):
         """Pick the next event to report.
         


### PR DESCRIPTION
# Description

Rather than pulling events one at a time off the stack, the commentary generator is now aware of all detected events within the max history length (as set by the user). This means it's able to associate events which are related. Events were restructured to include percentage of lap completed and how long ago the event happened. A secondary GPT call was added to determine who the camera should focus on, which appears to be reliable in testing. Additional prompt restructuring was done to improve text generation, including the addition of some information to make commentary more accurate (for example, the commentators now know how many laps have passed or how much time has passed, depending on how the race is structured, so it knows to commentate relative to beginning/end of race).

In the process of making this change, bug #79 was fixed by adding a sanity check. The race start is also detected in a more reliable way now, by looking as SessionState.

Fixes #74, #79 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Tested on multiple replays of different race types to ensure commentary was reasonable in most situations. This included races with both standing and rolling starts, as well as both lap and timed races.