### PR TITLE
14 add more camera variety

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -117,6 +117,62 @@ class App(ctk.CTk):
         )
         self.btn_start_stop.pack(padx=20, pady=20)
 
+    def _create_checkbox(self, master, name, text, default, variable={}):
+        """Create a checkbox for the frame.
+        
+        Creates a checkbox for the frame that is used to toggle a setting on or
+        off. If a default value is provided, the checkbox is set to that value.
+        
+        Args:
+            name (str): The name of the checkbox to create.
+            text (str): The text to display next to the checkbox.
+            default (str): The default value to set the checkbox to.
+            variable (dict): The dictionary to add the checkbox to.
+        """
+        # Create label
+        lbl = ctk.CTkLabel(
+            master=master,
+            text=text,
+            font=ctk.CTkFont(size=14)
+        )
+
+        # Grid label
+        lbl.grid(
+            row=self.row,
+            column=0,
+            sticky="e",
+            padx=20,
+            pady=(0, 20)
+        )
+
+        # Create checkbox
+        chk = ctk.CTkCheckBox(
+            master=master,
+            text=""
+        )
+
+        # If default value is provided, set checkbox to that value
+        if default == "1":
+            chk.select()
+        else:
+            chk.deselect()
+
+        # Grid checkbox
+        chk.grid(
+            row=self.row,
+            column=1,
+            columnspan=3,
+            sticky="ew",
+            padx=(0, 20),
+            pady=(0, 20)
+        )
+
+        # Increment row
+        self.row += 1
+
+        # Add checkbox to current settings
+        variable[self.current_section][name] = chk
+
     def _create_context(self):
         """Create the context frame and its components.
 
@@ -636,6 +692,16 @@ class App(ctk.CTk):
             variable=self.current_settings
         )
 
+        # Create realistic camera checkbox
+        default = common.settings["commentary"]["realistic_camera"]
+        self._create_checkbox(
+            self.frm_settings,
+            "realistic_camera",
+            "Use only realistic camera angles",
+            default,
+            variable=self.current_settings
+        )
+
         # Create memory limit entry box
         default = common.settings["commentary"]["memory_limit"]
         self._create_entry(
@@ -812,7 +878,7 @@ class App(ctk.CTk):
         # Update settings with values from entry boxes
         for key in self.current_settings:
             for setting in self.current_settings[key]:
-                new_setting = self.current_settings[key][setting].get()
+                new_setting = str(self.current_settings[key][setting].get())
                 common.settings[key][setting] = new_setting
 
         # Save settings to file

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -697,7 +697,7 @@ class App(ctk.CTk):
         self._create_checkbox(
             self.frm_settings,
             "realistic_camera",
-            "Use only realistic camera angles",
+            "Realistic Camera Angles",
             default,
             variable=self.current_settings
         )

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -42,8 +42,9 @@ class Camera:
                 "Rear Chase"
             )
             for cam in cams_to_remove:
-                del cameras[cam]
-                
+                if cam in cameras:
+                    del cameras[cam]
+
         # Return the dictionary
         return cameras
     
@@ -62,8 +63,17 @@ class Camera:
         Args:
             car_idx (int): Index of the car
         """
+        # Get the cameras
+        cameras = list(self.cameras.keys())
+
+        # Remove angles that don't focus on a specific car
+        bad_angles = ("Scenic", "Pit Lane", "Pit Lane 2")
+        for angle in bad_angles:
+            if angle in cameras:
+                cameras.remove(angle)
+
         # Choose a random camera
-        random_camera = random.choice(list(self.cameras.keys()))
+        random_camera = random.choice(cameras)
 
         # Change the camera
         self.change_camera(car_idx, self.cameras[random_camera])

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -72,8 +72,16 @@ class Camera:
             if angle in cameras:
                 cameras.remove(angle)
 
+        # Set the probability of the cameras
+        weights = []
+        for camera in cameras:
+            if "TV" in camera:
+                weights.append(5)
+            else:
+                weights.append(1)
+
         # Choose a random camera
-        random_camera = random.choice(cameras)
+        random_camera = random.choices(cameras, weights=weights, k=1)[0]
 
         # Change the camera
-        self.change_camera(car_idx, self.cameras[random_camera])
+        self.change_camera(car_idx, random_camera)

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -16,6 +16,9 @@ class Camera:
         # Camera Dictionary
         self.cameras = self._get_cameras()
 
+        # Store current camera
+        self.current_camera = None
+
     def _get_cameras(self):
         """Returns a dictionary of camera names and numbers
         
@@ -56,6 +59,7 @@ class Camera:
             camera_name (str): Name of the camera
         """
         common.ir.cam_switch_num(car_idx, self.cameras[camera_name])
+        self.current_camera = camera_name
 
     def choose_random_camera(self, car_idx):
         """Chooses a random camera for a specific car
@@ -71,6 +75,10 @@ class Camera:
         for angle in bad_angles:
             if angle in cameras:
                 cameras.remove(angle)
+
+        # Remove current camera
+        if self.current_camera in cameras:
+            cameras.remove(self.current_camera)
 
         # Set the probability of the cameras
         weights = []

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -76,7 +76,7 @@ class Camera:
         weights = []
         for camera in cameras:
             if "TV" in camera:
-                weights.append(5)
+                weights.append(10)
             else:
                 weights.append(1)
 

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -35,6 +35,8 @@ class Camera:
         # If realistic cameras is enabled, remove unrealistic cameras
         if common.settings["commentary"]["realistic_camera"] == "1":
             cams_to_remove = (
+                "Nose",
+                "Gearbox",
                 "LF Susp",
                 "RF Susp",
                 "LR Susp",

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -1,3 +1,5 @@
+import random
+
 from core import common
 
 
@@ -38,3 +40,15 @@ class Camera:
             camera_name (str): Name of the camera
         """
         common.ir.cam_switch_num(car_idx, self.cameras[camera_name])
+
+    def choose_random_camera(self, car_idx):
+        """Chooses a random camera for a specific car
+        
+        Args:
+            car_idx (int): Index of the car
+        """
+        # Choose a random camera
+        random_camera = random.choice(list(self.cameras.keys()))
+
+        # Change the camera
+        self.change_camera(car_idx, self.cameras[random_camera])

--- a/src/core/camera.py
+++ b/src/core/camera.py
@@ -29,6 +29,21 @@ class Camera:
         for camera in common.ir["CameraInfo"]["Groups"]:
             cameras[camera["GroupName"]] = camera["GroupNum"]
 
+        # If realistic cameras is enabled, remove unrealistic cameras
+        if common.settings["commentary"]["realistic_camera"] == "1":
+            cams_to_remove = (
+                "LF Susp",
+                "RF Susp",
+                "LR Susp",
+                "RR Susp",
+                "Cockpit",
+                "Chase",
+                "Far Chase",
+                "Rear Chase"
+            )
+            for cam in cams_to_remove:
+                del cameras[cam]
+                
         # Return the dictionary
         return cameras
     

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -1,6 +1,5 @@
 import os
 import time
-from pprint import pprint
 
 import elevenlabs
 from mutagen.mp3 import MP3
@@ -393,8 +392,6 @@ class TextGenerator:
                     "content": event_msg
                 }
             messages.append(event_msg)
-
-        pprint(messages)
 
         # Call the API for the main response
         response = self.client.chat.completions.create(

--- a/src/core/commentary.py
+++ b/src/core/commentary.py
@@ -416,7 +416,7 @@ class TextGenerator:
 
         # Switch the camera to the new target
         if next_camera is not None:
-            camera.change_camera(next_camera, "TV1")
+            camera.choose_random_camera(next_camera)
 
         # If the list is too long, remove the two oldest responses
         length = int(common.settings["commentary"]["memory_limit"]) * 2

--- a/src/utility/defaults.py
+++ b/src/utility/defaults.py
@@ -54,6 +54,7 @@ def create_settings_file(file_name):
         config.set("commentary", "pbp_voice", "Harry")
         config.set("commentary", "color_voice", "Elli")
         config.set("commentary", "color_chance", "0.5")
+        config.set("commentary", "realistic_camera", "1")
         config.set("commentary", "memory_limit", "10")
 
         # Set up system section


### PR DESCRIPTION
# Description

A method was added to choose a random camera (with a strong preference for TV camera angles for a consistent visual language), along with logic to avoid bad camera angles. An option was added to the UI to choose to use only realistic camera angles (i.e. no chase cam, since that's an impossible camera angle in real life), and the logic accounts for that setting accordingly. Any camera change made by commentary now chooses a random camera instead of defaulting to "TV1." Additionally, logic is in place to avoid choosing the same camera twice, therefore avoiding the sudden slide over motion which happens when focus is turned to a nearby car on the same angle.

Fixes #14 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Multiple replays were run for several laps to ensure choosing cameras was working as intended.