### PR TITLE
Updated in pits logic to correctly get pit status

### DIFF
--- a/src/core/events.py
+++ b/src/core/events.py
@@ -353,7 +353,11 @@ class Events:
                         common.drivers[j]["gap_to_leader"] = gap_to_leader
 
                         # Update pits status
-                        in_pits = common.ir["CarIdxOnPitRoad"][i]
+                        track_surface = common.ir["CarIdxTrackSurface"][i]
+                        if track_surface == 1 or track_surface == 2:
+                            in_pits = True
+                        else:
+                            in_pits = False
                         common.drivers[j]["in_pits"] = in_pits
 
                         # Update on track status


### PR DESCRIPTION
# Description

The in pits status is now correctly gathered using the SDK. This should also fix this issue.

Fixes #81 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

While a replay with this issue was not on hand, checking the data gathered from iRacing now correctly shows in pit status, which should fix this and several other issues.